### PR TITLE
Removed tokio runtime, using threads directly instead.

### DIFF
--- a/rusty-schedule-app/Cargo.toml
+++ b/rusty-schedule-app/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 rusty-schedule-core = { path = "../rusty-schedule-core" }
 notify-rust = "4.10.0"
 directories = "5.0.1"
-tokio = { version = "1.36.0", features = ["full"] }
 clap = { version = "4.4.18", features = ["derive"] }
 ratatui = { version = "0.26.0", optional = true }
 crossterm = "0.27.0"


### PR DESCRIPTION
No need for tokio runtime because the application is small and meant to be simple. Use threads from the standard library instead.